### PR TITLE
Troubleshoot qr code generation after batch

### DIFF
--- a/backend/routes/batches.js
+++ b/backend/routes/batches.js
@@ -206,8 +206,13 @@ router.get('/:batchId',
 
     // Add QR code information if available
     if (dbBatch && dbBatch.qr_code_data && dbBatch.qr_code_hash) {
+      const storedQr = dbBatch.qr_code_data;
+      const dataUrl = (typeof storedQr === 'string' && storedQr.startsWith('data:'))
+        ? storedQr
+        : `data:image/png;base64,${typeof storedQr === 'string' ? storedQr : Buffer.from(storedQr).toString('base64')}`;
+
       batch.qrCode = {
-        dataUrl: `data:image/png;base64,${Buffer.from(dbBatch.qr_code_data).toString('base64')}`,
+        dataUrl,
         batchUrl: `${process.env.BASE_URL || 'https://pharbit.com'}/verify/${batchId}`,
         hash: dbBatch.qr_code_hash,
         generatedAt: dbBatch.qr_code_generated_at
@@ -669,8 +674,13 @@ router.get('/:batchId/qr-code',
 
     // If QR code already exists, return it
     if (dbBatch.qr_code_data && dbBatch.qr_code_hash) {
+      const storedQr = dbBatch.qr_code_data;
+      const dataUrl = (typeof storedQr === 'string' && storedQr.startsWith('data:'))
+        ? storedQr
+        : `data:image/png;base64,${typeof storedQr === 'string' ? storedQr : Buffer.from(storedQr).toString('base64')}`;
+
       const qrCodeData = {
-        dataUrl: `data:image/png;base64,${Buffer.from(dbBatch.qr_code_data).toString('base64')}`,
+        dataUrl,
         batchUrl: `${process.env.BASE_URL || 'https://pharbit.com'}/verify/${batchId}`,
         hash: dbBatch.qr_code_hash
       };


### PR DESCRIPTION
Fix QR code data URL generation to prevent double-encoding and ensure proper display.

The existing logic would re-encode QR code data as base64 even if it was already a `data:` URL, leading to corrupted QR images. This PR modifies the `/:batchId` and `/:batchId/qr-code` endpoints to detect pre-existing `data:` URLs and use them directly, or correctly base64-encode other formats.

---
<a href="https://cursor.com/background-agent?bcId=bc-f80dc9b7-c851-494d-8eb5-30bb45c08106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f80dc9b7-c851-494d-8eb5-30bb45c08106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

