### PR TITLE
Start pharbitchain api server

### DIFF
--- a/contracts/deployed-contracts.json
+++ b/contracts/deployed-contracts.json
@@ -2,5 +2,5 @@
   "RecallManagement": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
   "AntiCounterfeitVerification": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
   "network": "hardhat",
-  "timestamp": "2025-10-02T18:40:35.715Z"
+  "timestamp": "2025-10-02T19:39:52.468Z"
 }


### PR DESCRIPTION
Correct local development environment service startup and port assignments.

The backend API was incorrectly occupying port 3000, preventing the frontend from loading, and the Hardhat node failed to start due to an installation issue. This ensures the frontend runs on port 3000, the backend on port 3001, and the Hardhat node on port 8545, with all necessary dependencies installed for a functional local development setup. Note: This PR reflects operational fixes and environment setup rather than code changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-6500cba1-7d13-443b-8259-20a23ff7239b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6500cba1-7d13-443b-8259-20a23ff7239b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

